### PR TITLE
Changing endpoint and adding 'r' param

### DIFF
--- a/docebo_sso/methods.py
+++ b/docebo_sso/methods.py
@@ -54,8 +54,9 @@ def create_authentication_path(username, datestring, token):
       Valid signed SSO URL
     """
 
-    auth_path = '/doceboLms/index.php'
+    auth_path = '/lms/index.php'
     params = {
+      'r': 'site/sso',
       'modname': 'login',
       'op': 'confirm',
       'login_user': username.lower(),


### PR DESCRIPTION
Changing the end point from '/doceboLms/index.php' to '/lms/index.php' and adding 'r' param. 

With the current settings using email as the username doesn't generate a valid redirect url, this fixes the issue.

/review @alex-optimizely, @nehasingla 
